### PR TITLE
Compatibility Fix to SMAPI 4.1.0

### DIFF
--- a/BetterFriendship/BetterFriendship/BetterFriendship.csproj
+++ b/BetterFriendship/BetterFriendship/BetterFriendship.csproj
@@ -9,4 +9,15 @@
     <PackageReference Include="System.Runtime.Caching" Version="8.0.0" />
   </ItemGroup>
 
+	<PropertyGroup>
+		<BundleExtraAssemblies>System</BundleExtraAssemblies>
+		<IgnoreModFilePatterns>
+			^Microsoft.(?!.*(Toolkit.Diagnostics.dll)), <!-- Everyone but MS.Toolkit.Diagnostics-->
+			.*[/\\]Microsoft.*, <!-- CodeDiagnostics in a bunch of languages?-->
+			^runtimes[/\\].*,
+			^JetBrains,<!-- Should never be bundled.-->
+			^Skia <!-- Skiasharp is included with the game-->
+		</IgnoreModFilePatterns>
+	</PropertyGroup>
+
 </Project>

--- a/BetterFriendship/BetterFriendship/manifest.json
+++ b/BetterFriendship/BetterFriendship/manifest.json
@@ -1,11 +1,11 @@
 ﻿{
     "Name": "Better Friendship",
     "Author": "Urbanyeti",
-    "Version": "1.1.2",
+    "Version": "1.1.3-unofficial.1-MaximillianRW",
     "Description": "Adds thought bubbles over villagers to indicate their favorite gifts from your inventory and when they'd like to talk.",
     "UniqueID": "BetterFriendship",
     "EntryDll": "BetterFriendship.dll",
-    "MinimumApiVersion": "4.0.0",
+    "MinimumApiVersion": "4.1.0",
     "UpdateKeys": [ "Nexus:10287" ],
     "Dependencies": [
         {


### PR DESCRIPTION
Changes to project file and manifest.json to assert compatibility with recent SMAPI changes, since System.Runtimes.Caching is not internal to SMAPI anymore.